### PR TITLE
Script removes unneeded files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,9 +56,9 @@ CXX=$CXXCOMP CC=$CCOMP cmake . -DNO_NATIVE_OPTIMIZATION=1 -DCMAKE_BUILD_TYPE=${C
 make
 
 # Package Server
-mkdir Server/Licenses
-cp Install/ThirdPartyLicenses/* Server/Licenses/
+cp -r Install/ThirdPartyLicenses/ Server/
 cp CONTRIBUTORS Server/
 cp LICENSE Server/
+rm Server/delete_windows_service.cmd Server/hg Server/hg.supp Server/install_windows_service.cmd Server/Plugins/.gitignore Server/vg Server/vg.supp
 tar -cvzf Cuberite.tar.gz Server/*
 sha1sum Cuberite.tar.gz > Cuberite.tar.gz.sha1


### PR DESCRIPTION
Licenses -> ThirdPartyLicenses for consistency with Windows builds.
Removes debug scripts.

Fixes https://github.com/cuberite/cuberite/issues/3095 when merged with https://github.com/cuberite/cuberite/pull/3590